### PR TITLE
Update to run with python 3.8

### DIFF
--- a/pyping/core.py
+++ b/pyping/core.py
@@ -22,12 +22,15 @@ import struct
 import sys
 import time
 
-if sys.platform.startswith("win32"):
-    # On Windows, the best timer is time.clock()
-    default_timer = time.clock
+if sys.version_info >= (3, 3):
+	default_timer = time.perf_counter
 else:
-    # On most other platforms the best timer is time.time()
-    default_timer = time.time
+	if sys.platform.startswith("win32"):
+	    # On Windows, the best timer is time.clock()
+	    default_timer = time.clock
+	else:
+	    # On most other platforms the best timer is time.time()
+	    default_timer = time.time
 
 # ICMP parameters
 ICMP_ECHOREPLY = 0  # Echo reply (per RFC792)

--- a/pyping/core.py
+++ b/pyping/core.py
@@ -23,14 +23,14 @@ import sys
 import time
 
 if sys.version_info >= (3, 3):
-	default_timer = time.perf_counter
+    default_timer = time.perf_counter
 else:
-	if sys.platform.startswith("win32"):
-	    # On Windows, the best timer is time.clock()
-	    default_timer = time.clock
-	else:
-	    # On most other platforms the best timer is time.time()
-	    default_timer = time.time
+    if sys.platform.startswith("win32"):
+        # On Windows, the best timer is time.clock()
+        default_timer = time.clock
+    else:
+        # On most other platforms the best timer is time.time()
+        default_timer = time.time
 
 # ICMP parameters
 ICMP_ECHOREPLY = 0  # Echo reply (per RFC792)


### PR DESCRIPTION
Updated the default clock from deprecated time.clock to time.perf_counter